### PR TITLE
Integrate Kubernetes for production Orleans clustering

### DIFF
--- a/src/Argon.Api/Argon.Api.csproj
+++ b/src/Argon.Api/Argon.Api.csproj
@@ -34,6 +34,7 @@
         <PackageReference Include="Microsoft.Orleans.Serialization" Version="8.2.0"/>
         <PackageReference Include="Microsoft.Orleans.Server" Version="8.2.0"/>
         <PackageReference Include="Npgsql" Version="8.0.5"/>
+        <PackageReference Include="Orleans.Clustering.Kubernetes" Version="8.2.0"/>
         <PackageReference Include="OrleansDashboard" Version="8.2.0"/>
         <PackageReference Include="Otp.NET" Version="1.4.0"/>
         <PackageReference Include="R3" Version="1.2.9"/>

--- a/src/Argon.Api/Extensions/OrleansExtension.cs
+++ b/src/Argon.Api/Extensions/OrleansExtension.cs
@@ -1,5 +1,6 @@
 namespace Argon.Api.Extensions;
 
+using Orleans.Clustering.Kubernetes;
 using Orleans.Configuration;
 using Orleans.Storage;
 
@@ -25,7 +26,9 @@ public static class OrleansExtension
                 options.Invariant              = "Npgsql";
                 options.ConnectionString       = builder.Configuration.GetConnectionString("DefaultConnection");
                 options.GrainStorageSerializer = new MemoryPackStorageSerializer();
-            }).AddMemoryGrainStorageAsDefault().UseLocalhostClustering().UseDashboard(o => o.Port = 22832);
+            }).AddReminders().AddMemoryGrainStorage("CacheStorage").UseDashboard(o => o.Port = 22832);
+            if (builder.Environment.IsDevelopment()) siloBuilder.UseLocalhostClustering();
+            else siloBuilder.UseKubeMembership();
         });
 
         return builder;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for Kubernetes clustering with the addition of `Orleans.Clustering.Kubernetes`.
	- Enhanced Orleans configuration to include reminder functionality and improved storage strategy.
	- Adaptive clustering based on the environment (development vs. production).

- **Bug Fixes**
	- Improved consistency in project file formatting.

- **Documentation**
	- Updated method documentation to reflect changes in Orleans configuration and clustering strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->