### PR TITLE
Refactor CPU usage parsing logic

### DIFF
--- a/src/Argon.Api/Features/Orleanse/BalanceRule.cs
+++ b/src/Argon.Api/Features/Orleanse/BalanceRule.cs
@@ -69,10 +69,9 @@ public class KubeResources(IHostEnvironment env, IServiceProvider serviceProvide
     static double ParseCpuUsage(string cpuUsageStr)
     {
         if (cpuUsageStr.EndsWith("n"))
-        {
-            var nanoCores = double.Parse(cpuUsageStr.Replace("n", ""), CultureInfo.InvariantCulture);
-            return nanoCores / 1_000_000;
-        }
+            return double.Parse(cpuUsageStr.Replace("n", ""), CultureInfo.InvariantCulture) / 1_000_000;
+        if (cpuUsageStr.EndsWith("u"))
+            return double.Parse(cpuUsageStr.Replace("u", ""), CultureInfo.InvariantCulture) / 1_000;
         if (cpuUsageStr.EndsWith("m"))
             return double.Parse(cpuUsageStr.Replace("m", ""), CultureInfo.InvariantCulture);
         var cores = double.Parse(cpuUsageStr, CultureInfo.InvariantCulture);


### PR DESCRIPTION
Simplified the `ParseCpuUsage` method by removing unnecessary braces and consolidating the return statements. Added support for parsing micro (u) units in addition to nano (n) and milli (m).