### PR TITLE
Add Sentry integration to web application builder

### DIFF
--- a/src/Argon.Entry/Program.cs
+++ b/src/Argon.Entry/Program.cs
@@ -16,7 +16,7 @@ using Orleans.Configuration;
 using Orleans.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
-
+builder.AddSentry(builder.Configuration.GetConnectionString("Sentry"));
 builder.WebHost.ConfigureKestrel(options =>
 {
     options.Limits.KeepAliveTimeout                  = TimeSpan.FromSeconds(400);


### PR DESCRIPTION
Previously, the Sentry integration was missing from the application's initialization. This commit adds Sentry configuration using the connection string from the application's settings, which will help in tracking and diagnosing errors.