### PR TITLE
Update Dockerfiles and project files for Argon.Api and Entry

### DIFF
--- a/src/Argon.Api/Argon.Api.csproj
+++ b/src/Argon.Api/Argon.Api.csproj
@@ -9,58 +9,60 @@
 
         <CompilerGeneratedFilesOutputPath>Generated</CompilerGeneratedFilesOutputPath>
         <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+        <DockerfileContext>..\..</DockerfileContext>
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs"/>
-        <None Include="$(CompilerGeneratedFilesOutputPath)/**/*.cs"/>
+        <Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
+        <None Include="$(CompilerGeneratedFilesOutputPath)/**/*.cs" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.StackExchange.Redis" Version="9.0.0"/>
-        <PackageReference Include="Fluid.Core" Version="2.14.0"/>
-        <PackageReference Include="Flurl.Http" Version="4.0.2"/>
-        <PackageReference Include="Flurl.Http.Newtonsoft" Version="0.9.1"/>
-        <PackageReference Include="Genbox.SimpleS3.Core" Version="3.2.7"/>
-        <PackageReference Include="Genbox.SimpleS3.Extensions.GenericS3" Version="3.2.7"/>
-        <PackageReference Include="Genbox.SimpleS3.Extensions.HttpClient" Version="3.2.7"/>
-        <PackageReference Include="Grpc.AspNetCore" Version="2.67.0"/>
-        <PackageReference Include="Grpc.AspNetCore.Web" Version="2.67.0"/>
-        <PackageReference Include="MessagePipe" Version="1.8.1"/>
+        <PackageReference Include="Aspire.StackExchange.Redis" Version="9.0.0" />
+        <PackageReference Include="Fluid.Core" Version="2.14.0" />
+        <PackageReference Include="Flurl.Http" Version="4.0.2" />
+        <PackageReference Include="Flurl.Http.Newtonsoft" Version="0.9.1" />
+        <PackageReference Include="Genbox.SimpleS3.Core" Version="3.2.7" />
+        <PackageReference Include="Genbox.SimpleS3.Extensions.GenericS3" Version="3.2.7" />
+        <PackageReference Include="Genbox.SimpleS3.Extensions.HttpClient" Version="3.2.7" />
+        <PackageReference Include="Grpc.AspNetCore" Version="2.67.0" />
+        <PackageReference Include="Grpc.AspNetCore.Web" Version="2.67.0" />
+        <PackageReference Include="MessagePipe" Version="1.8.1" />
         <PackageReference Include="MessagePipe.Analyzer" Version="1.8.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10"/>
-        <PackageReference Include="Argon.Sfu.Protocol" Version="1.26.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
+        <PackageReference Include="Argon.Sfu.Protocol" Version="1.26.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.10">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1"/>
-        <PackageReference Include="Microsoft.Orleans.BroadcastChannel" Version="8.2.0"/>
-        <PackageReference Include="Microsoft.Orleans.Persistence.AdoNet" Version="8.2.0"/>
-        <PackageReference Include="Microsoft.Orleans.Runtime" Version="8.2.0"/>
-        <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.2.0"/>
-        <PackageReference Include="Microsoft.Orleans.Serialization" Version="8.2.0"/>
-        <PackageReference Include="Microsoft.Orleans.Serialization.MessagePack" Version="8.2.0"/>
-        <PackageReference Include="Microsoft.Orleans.Server" Version="8.2.0"/>
-        <PackageReference Include="Microsoft.Orleans.Streaming" Version="8.2.0"/>
-        <PackageReference Include="Npgsql" Version="8.0.5"/>
-        <PackageReference Include="Orleans.Clustering.Kubernetes" Version="8.2.0"/>
-        <PackageReference Include="OrleansDashboard" Version="8.2.0"/>
-        <PackageReference Include="Otp.NET" Version="1.4.0"/>
-        <PackageReference Include="R3" Version="1.2.9"/>
-        <PackageReference Include="Riok.Mapperly" Version="4.1.0"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0"/>
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.9.0"/>
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1"/>
+        <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+        <PackageReference Include="Microsoft.Orleans.BroadcastChannel" Version="8.2.0" />
+        <PackageReference Include="Microsoft.Orleans.Persistence.AdoNet" Version="8.2.0" />
+        <PackageReference Include="Microsoft.Orleans.Runtime" Version="8.2.0" />
+        <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.2.0" />
+        <PackageReference Include="Microsoft.Orleans.Serialization" Version="8.2.0" />
+        <PackageReference Include="Microsoft.Orleans.Serialization.MessagePack" Version="8.2.0" />
+        <PackageReference Include="Microsoft.Orleans.Server" Version="8.2.0" />
+        <PackageReference Include="Microsoft.Orleans.Streaming" Version="8.2.0" />
+        <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+        <PackageReference Include="Npgsql" Version="8.0.5" />
+        <PackageReference Include="Orleans.Clustering.Kubernetes" Version="8.2.0" />
+        <PackageReference Include="OrleansDashboard" Version="8.2.0" />
+        <PackageReference Include="Otp.NET" Version="1.4.0" />
+        <PackageReference Include="R3" Version="1.2.9" />
+        <PackageReference Include="Riok.Mapperly" Version="4.1.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.9.0" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.2.1" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Argon.Contracts\Argon.Shared.csproj"/>
-        <ProjectReference Include="..\ServiceDefaults\ServiceDefaults.csproj"/>
+        <ProjectReference Include="..\Argon.Contracts\Argon.Shared.csproj" />
+        <ProjectReference Include="..\ServiceDefaults\ServiceDefaults.csproj" />
     </ItemGroup>
 
     <ItemGroup>
@@ -73,11 +75,5 @@
         <None Update="Resources\**\*">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-    </ItemGroup>
-
-    <ItemGroup>
-        <Content Include="..\..\.dockerignore">
-            <Link>.dockerignore</Link>
-        </Content>
     </ItemGroup>
 </Project>

--- a/src/Argon.Api/Dockerfile
+++ b/src/Argon.Api/Dockerfile
@@ -1,26 +1,28 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM ghcr.io/argon-chat/secrets:4 AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
-EXPOSE 8081
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Build.props", "."]
 COPY ["src/Argon.Api/Argon.Api.csproj", "src/Argon.Api/"]
 COPY ["src/Argon.Contracts/Argon.Shared.csproj", "src/Argon.Contracts/"]
 COPY ["src/ServiceDefaults/ServiceDefaults.csproj", "src/ServiceDefaults/"]
-RUN dotnet restore "src/Argon.Api/Argon.Api.csproj"
+RUN dotnet restore "./src/Argon.Api/Argon.Api.csproj"
 COPY . .
 WORKDIR "/src/src/Argon.Api"
-RUN dotnet build "Argon.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build
+RUN dotnet build "./Argon.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "Argon.Api.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "./Argon.Api.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 COPY src/Argon.Api/Migrations/*.sql /app/publish/Migrations/
 
 FROM base AS final
+ENV Kestrel__Endpoints__Https__Certificate__Path="/origin.argon.gl.pem" \
+    Kestrel__Endpoints__Https__Certificate__KeyPath="/origin.argon.gl.key"
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "Argon.Api.dll"]

--- a/src/Argon.Api/Properties/launchSettings.json
+++ b/src/Argon.Api/Properties/launchSettings.json
@@ -1,14 +1,22 @@
 {
-  "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
     "http": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
       "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "dotnetRunMessages": true
+    },
+    "Container (Dockerfile)": {
+      "commandName": "Docker",
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
+      "environmentVariables": {
+        "ASPNETCORE_HTTP_PORTS": "8080"
+      },
+      "publishAllPorts": true,
+      "useSSL": false
     }
-  }
+  },
+  "$schema": "http://json.schemastore.org/launchsettings.json"
 }

--- a/src/Argon.Entry/Argon.Entry.csproj
+++ b/src/Argon.Entry/Argon.Entry.csproj
@@ -7,17 +7,16 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
         <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
         <UserSecretsId>b90ebea2-7ea4-447f-b92f-46da1cfd6437</UserSecretsId>
+        <DockerfileContext>..\..</DockerfileContext>
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Argon.Api\Argon.Api.csproj"/>
-        <ProjectReference Include="..\ServiceDefaults\ServiceDefaults.csproj"/>
+      <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <Content Include="..\..\.dockerignore">
-            <Link>.dockerignore</Link>
-        </Content>
+        <ProjectReference Include="..\Argon.Api\Argon.Api.csproj" />
+        <ProjectReference Include="..\ServiceDefaults\ServiceDefaults.csproj" />
     </ItemGroup>
 
 </Project>

--- a/src/Argon.Entry/Dockerfile
+++ b/src/Argon.Entry/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM ghcr.io/argon-chat/secrets:4 AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
@@ -7,20 +7,23 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Build.props", "."]
 COPY ["src/Argon.Entry/Argon.Entry.csproj", "src/Argon.Entry/"]
 COPY ["src/Argon.Api/Argon.Api.csproj", "src/Argon.Api/"]
 COPY ["src/Argon.Contracts/Argon.Shared.csproj", "src/Argon.Contracts/"]
 COPY ["src/ServiceDefaults/ServiceDefaults.csproj", "src/ServiceDefaults/"]
-RUN dotnet restore "src/Argon.Entry/Argon.Entry.csproj"
+RUN dotnet restore "./src/Argon.Entry/Argon.Entry.csproj"
 COPY . .
 WORKDIR "/src/src/Argon.Entry"
-RUN dotnet build "Argon.Entry.csproj" -c $BUILD_CONFIGURATION -o /app/build
+RUN dotnet build "./Argon.Entry.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "Argon.Entry.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "./Argon.Entry.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 FROM base AS final
+ENV Kestrel__Endpoints__Https__Certificate__Path="/origin.argon.gl.pem" \
+    Kestrel__Endpoints__Https__Certificate__KeyPath="/origin.argon.gl.key"
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "Argon.Entry.dll"]

--- a/src/Argon.Entry/Properties/launchSettings.json
+++ b/src/Argon.Entry/Properties/launchSettings.json
@@ -1,33 +1,24 @@
-﻿{
-  "$schema": "http://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:25559",
-      "sslPort": 44393
-    }
-  },
+{
   "profiles": {
     "http": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5278",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5278"
     },
     "https": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:7183;http://localhost:5278",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:7183;http://localhost:5278"
     },
     "IIS Express": {
       "commandName": "IISExpress",
@@ -36,6 +27,26 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "Container (Dockerfile)": {
+      "commandName": "Docker",
+      "launchBrowser": true,
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
+      "environmentVariables": {
+        "ASPNETCORE_HTTPS_PORTS": "8081",
+        "ASPNETCORE_HTTP_PORTS": "8080"
+      },
+      "publishAllPorts": true,
+      "useSSL": true
+    }
+  },
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:25559",
+      "sslPort": 44393
     }
   }
 }


### PR DESCRIPTION
Update Dockerfiles and project files for Argon.Api and Entry

- Add <DockerfileContext> property to Argon.Api.csproj and Argon.Entry.csproj
- Reformat <Compile>, <None>, <PackageReference>, and <ProjectReference> elements in Argon.Api.csproj
- Add Microsoft.VisualStudio.Azure.Containers.Tools.Targets package to both projects
- Remove <Content> element for .dockerignore from both projects
- Change base image in Dockerfiles to ghcr.io/argon-chat/secrets:4
- Remove EXPOSE 8081 from Argon.Api Dockerfile
- Update COPY command in Dockerfiles to include ["Directory.Build.props", "."]
- Use relative paths for dotnet restore, build, and publish commands in Dockerfiles
- Add environment variables for Kestrel HTTPS certificate paths in Dockerfiles
- Reformat ENTRYPOINT command in Dockerfiles
- Update launchSettings.json for Docker profiles with new environment variables and schema position